### PR TITLE
Refactored search.js to use fetch to read JSON

### DIFF
--- a/src/data/search.js
+++ b/src/data/search.js
@@ -1,21 +1,19 @@
-import lunr from 'lunr'
-import fs from 'fs/promises'
+import lunr from "lunr";
 
-const url = new URL('./ksbs.json', import.meta.url)
-const json = await fs.readFile(url, 'utf-8')
-const ksbs = JSON.parse(json)
+const response = await fetch("./src/data/ksbs.json");
+const ksbs = await response.json();
 
 const idx = lunr(function () {
-  this.ref('Code')
+  this.ref("Code");
 
-  this.field('Code')
-  this.field('Description')
-  this.field('GradingCriteria')
-  this.field('DistinctionCriteria')
+  this.field("Code");
+  this.field("Description");
+  this.field("GradingCriteria");
+  this.field("DistinctionCriteria");
 
   ksbs.forEach(function (ksb) {
-    this.add(ksb)
-  }, this)
-})
+    this.add(ksb);
+  }, this);
+});
 
-export default idx
+export default idx;


### PR DESCRIPTION
Hey,

I encountered an issue when I reached the third task and tried to import from `search.js`.

The error was: "Uncaught Error: Module 'fs/promises' has been externalized for browser compatibility. Cannot access 'fs/promises.readFile' in client code." 

To resolve this, I added a fix that uses fetch instead of fs to access the JSON file,. 

I have tested it on chrome and edge and it works fine now.